### PR TITLE
[AI Worker] 实现博客首页（文章列表）

### DIFF
--- a/docs/.vitepress/data/posts.ts
+++ b/docs/.vitepress/data/posts.ts
@@ -3,6 +3,7 @@ import type {
   PostArchiveGroup,
   PostCategoryGroup,
   PostFilterOptions,
+  PostPage,
   PostTagGroup
 } from '../types/post';
 import { comparePosts, shouldIncludePost } from './posts.data';
@@ -216,6 +217,29 @@ export function getPostsByMonth(
   options: Pick<PostFilterOptions, 'isProduction'> = {}
 ): Post[] {
   return getAllPosts(posts, { ...options, month });
+}
+
+export function paginatePosts(
+  posts: Post[],
+  page: number,
+  pageSize: number,
+  options: Pick<PostFilterOptions, 'isProduction'> = {}
+): PostPage {
+  const visiblePosts = getAllPosts(posts, options);
+  const normalizedPageSize = Number.isFinite(pageSize) && pageSize > 0 ? Math.floor(pageSize) : 1;
+  const total = visiblePosts.length;
+  const totalPages = Math.max(1, Math.ceil(total / normalizedPageSize));
+  const requestedPage = Number.isFinite(page) ? Math.floor(page) : 1;
+  const currentPage = Math.min(Math.max(requestedPage, 1), totalPages);
+  const startIndex = (currentPage - 1) * normalizedPageSize;
+
+  return {
+    items: visiblePosts.slice(startIndex, startIndex + normalizedPageSize),
+    total,
+    totalPages,
+    currentPage,
+    pageSize: normalizedPageSize
+  };
 }
 
 export function getAdjacentPosts(

--- a/docs/.vitepress/theme/components/HomePage.vue
+++ b/docs/.vitepress/theme/components/HomePage.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import posts from '../../data/posts.data';
+import { paginatePosts } from '../../data/posts';
+import type { PostPage } from '../../types/post';
+import PostCard from './PostCard.vue';
+
+const PAGE_SIZE = 5;
+const currentPage = ref(1);
+
+const postPage = computed<PostPage>(() => paginatePosts(posts, currentPage.value, PAGE_SIZE));
+const hasPreviousPage = computed(() => postPage.value.currentPage > 1);
+const hasNextPage = computed(() => postPage.value.currentPage < postPage.value.totalPages);
+
+function goToPreviousPage(): void {
+  if (!hasPreviousPage.value) {
+    return;
+  }
+
+  currentPage.value -= 1;
+}
+
+function goToNextPage(): void {
+  if (!hasNextPage.value) {
+    return;
+  }
+
+  currentPage.value += 1;
+}
+</script>
+
+<template>
+  <section class="home-page">
+    <header class="home-page__hero">
+      <p class="home-page__eyebrow">最新文章</p>
+      <h1>博客首页</h1>
+      <p class="home-page__intro">
+        按置顶优先级与发布时间展示文章，支持分页浏览全部内容。
+      </p>
+    </header>
+
+    <div v-if="postPage.items.length" class="home-page__list">
+      <PostCard v-for="post in postPage.items" :key="post.slug" :post="post" />
+    </div>
+
+    <p v-else class="home-page__empty">当前暂无可展示的文章。</p>
+
+    <nav class="home-pagination" aria-label="首页文章分页">
+      <button
+        type="button"
+        class="home-pagination__button"
+        :disabled="!hasPreviousPage"
+        @click="goToPreviousPage"
+      >
+        上一页
+      </button>
+
+      <p class="home-pagination__status">
+        第 {{ postPage.currentPage }} / {{ postPage.totalPages }} 页，共 {{ postPage.total }} 篇
+      </p>
+
+      <button
+        type="button"
+        class="home-pagination__button"
+        :disabled="!hasNextPage"
+        @click="goToNextPage"
+      >
+        下一页
+      </button>
+    </nav>
+  </section>
+</template>

--- a/docs/.vitepress/theme/components/PostCard.vue
+++ b/docs/.vitepress/theme/components/PostCard.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { withBase } from 'vitepress';
+import { normalizeCategorySlug, normalizeTagSlug } from '../../data/posts';
+import type { Post } from '../../types/post';
+
+const props = defineProps<{
+  post: Post;
+}>();
+
+const categoryLinks = computed(() =>
+  props.post.categories.map((category) => ({
+    name: category,
+    url: withBase(`/categories/${normalizeCategorySlug(category)}`)
+  }))
+);
+
+const tagLinks = computed(() =>
+  props.post.tags.map((tag) => ({
+    name: tag,
+    url: withBase(`/tags/${normalizeTagSlug(tag)}`)
+  }))
+);
+</script>
+
+<template>
+  <article class="post-card">
+    <div class="post-card__header">
+      <span v-if="post.pinned" class="post-card__badge">置顶</span>
+      <time class="post-card__date" :datetime="post.date">{{ post.date }}</time>
+    </div>
+
+    <h2 class="post-card__title">
+      <a :href="withBase(post.url)">{{ post.title }}</a>
+    </h2>
+
+    <div v-if="categoryLinks.length || tagLinks.length" class="post-card__meta">
+      <div v-if="categoryLinks.length" class="post-card__meta-group">
+        <span class="post-card__meta-label">分类</span>
+        <div class="post-card__meta-list">
+          <a
+            v-for="category in categoryLinks"
+            :key="category.url"
+            class="post-card__chip"
+            :href="category.url"
+          >
+            {{ category.name }}
+          </a>
+        </div>
+      </div>
+
+      <div v-if="tagLinks.length" class="post-card__meta-group">
+        <span class="post-card__meta-label">标签</span>
+        <div class="post-card__meta-list">
+          <a v-for="tag in tagLinks" :key="tag.url" class="post-card__chip is-tag" :href="tag.url">
+            # {{ tag.name }}
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <p class="post-card__description">{{ post.description }}</p>
+  </article>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import Layout from './Layout.vue';
 import ArchivesPage from './components/ArchivesPage.vue';
 import CategoriesPage from './components/CategoriesPage.vue';
 import CategoryDetailPage from './components/CategoryDetailPage.vue';
+import HomePage from './components/HomePage.vue';
 import TagDetailPage from './components/TagDetailPage.vue';
 import TagsPage from './components/TagsPage.vue';
 import './style.css';
@@ -12,6 +13,7 @@ const theme = {
   extends: DefaultTheme,
   Layout,
   enhanceApp({ app }) {
+    app.component('HomePage', HomePage);
     app.component('ArchivesPage', ArchivesPage);
     app.component('CategoriesPage', CategoriesPage);
     app.component('CategoryDetailPage', CategoryDetailPage);

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -440,6 +440,211 @@ a {
   font-size: 0.95rem;
 }
 
+.home-page {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.home-page__hero {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border: 1px solid var(--site-border);
+  border-radius: var(--site-radius);
+  background:
+    linear-gradient(135deg, rgba(29, 111, 95, 0.12), rgba(255, 255, 255, 0.92)),
+    var(--site-surface-strong);
+}
+
+.home-page__hero h1 {
+  margin: 0;
+}
+
+.home-page__eyebrow {
+  margin: 0;
+  color: var(--site-accent);
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.home-page__intro,
+.home-page__empty {
+  margin: 0;
+  max-width: 42rem;
+  color: var(--site-muted);
+}
+
+.home-page__empty {
+  padding: 1.25rem 1rem;
+  border: 1px dashed rgba(29, 111, 95, 0.24);
+  border-radius: var(--site-radius-sm);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.home-page__list {
+  display: grid;
+  gap: 1rem;
+}
+
+.post-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.35rem;
+  border: 1px solid var(--site-border);
+  border-radius: var(--site-radius);
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 16px 30px rgba(31, 41, 51, 0.05);
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.post-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(29, 111, 95, 0.24);
+  box-shadow: 0 20px 36px rgba(31, 41, 51, 0.08);
+}
+
+.post-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.post-card__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(29, 111, 95, 0.12);
+  color: var(--site-accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.post-card__date {
+  color: var(--site-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.post-card__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.2vw, 1.8rem);
+  line-height: 1.2;
+}
+
+.post-card__title a {
+  color: var(--site-text);
+  text-decoration: none;
+}
+
+.post-card__title a:hover {
+  color: var(--site-accent);
+}
+
+.post-card__meta {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.post-card__meta-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.post-card__meta-label {
+  color: var(--site-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.post-card__meta-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.post-card__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.42rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(29, 111, 95, 0.14);
+  color: var(--site-accent);
+  text-decoration: none;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.post-card__chip:hover {
+  transform: translateY(-1px);
+  box-shadow: inset 0 0 0 1px rgba(29, 111, 95, 0.24);
+}
+
+.post-card__chip.is-tag {
+  color: #9a4d19;
+  box-shadow: inset 0 0 0 1px rgba(154, 77, 25, 0.16);
+}
+
+.post-card__description {
+  margin: 0;
+  color: var(--site-muted);
+  line-height: 1.8;
+}
+
+.home-pagination {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.home-pagination__button {
+  min-width: 6.5rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--site-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--site-text);
+  font: inherit;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.home-pagination__button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  color: var(--site-accent);
+  border-color: rgba(29, 111, 95, 0.24);
+  box-shadow: 0 16px 30px rgba(31, 41, 51, 0.06);
+}
+
+.home-pagination__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.home-pagination__status {
+  margin: 0;
+  text-align: center;
+  color: var(--site-muted);
+}
+
 .archives-page {
   display: grid;
   gap: 2rem;
@@ -786,6 +991,7 @@ a {
     padding: 1.2rem 1rem;
   }
 
+  .home-page__hero,
   .archives-page__hero {
     padding: 1.15rem;
   }
@@ -815,6 +1021,19 @@ a {
   .archive-post {
     grid-template-columns: minmax(0, 1fr);
     gap: 0.35rem;
+  }
+
+  .post-card {
+    padding: 1.1rem;
+  }
+
+  .home-pagination {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .home-pagination__button,
+  .home-pagination__status {
+    width: 100%;
   }
 
   .tag-chip {

--- a/docs/.vitepress/types/post.ts
+++ b/docs/.vitepress/types/post.ts
@@ -36,6 +36,14 @@ export interface PostCategoryGroup {
   count: number;
 }
 
+export interface PostPage {
+  items: Post[];
+  total: number;
+  totalPages: number;
+  currentPage: number;
+  pageSize: number;
+}
+
 export interface PostFilterOptions {
   category?: string;
   tag?: string;

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,3 @@
-# blog-system
+# 首页
 
-一个基于 VitePress 的博客系统初始化工程。
-
-## Quick Start
-
-```bash
-npm install
-npm run dev
-```
-
-访问 `http://localhost:5173` 查看站点。
-
-## Structure
-
-- `docs/`: VitePress 文档根目录
-- `docs/posts/`: 文章内容目录
-- `docs/.vitepress/theme/`: 主题扩展入口
-- `components/`: 预留的共享组件目录
-- `public/`: 静态资源目录
+<HomePage />


### PR DESCRIPTION
## Summary

This PR was generated automatically by AI Worker for issue #58.

### Plan

## AI Worker Plan

**Issue:** #58 — 实现博客首页（文章列表）

### Understanding
需要把当前 `docs/index.md` 的占位首页改成真正的博客首页，复用现有文章数据源 `docs/.vitepress/data/posts.data.ts` 中的排序规则，让置顶文章继续按 `comparePosts(a: Post, b: Post): number` 优先显示，并在首页卡片上展示 `title`、`date`、`categories`、`tags`、`description`。基于当前仓库的页面模式，首页应像 `docs/archives/index.md` + `ArchivesPage.vue` 一样，由 Markdown 页面挂载主题组件，并在组件内实现分页而不是无限滚动，因为验收标准明确要求“分页功能正常”。

### Proposed Steps
1. 将 [`docs/index.md`](/private/tmp/repos/blog-system/docs/index.md) 从当前纯说明文档替换为首页入口，采用与 [`docs/archives/index.md`](/private/tmp/repos/blog-system/docs/archives/index.md) 的 `# 标题 + <ArchivesPage />` 相同模式，改成 `# 首页` + `<HomePage />`。
   需要在主题入口 [`docs/.vitepress/theme/index.ts`](/private/tmp/repos/blog-system/docs/.vitepress/theme/index.ts) 的 `enhanceApp({ app })` 中新增 `app.component('HomePage', HomePage)`，保持与 `ArchivesPage`、`CategoriesPage`、`TagsPage` 的注册方式一致。
   这里不新增页面路由逻辑，直接复用 VitePress 对 `/` -> `docs/index.md` 的映射；验收时应以当前示例数据验证第 1 页包含置顶文章 `release-notes.md`，并优先于 `2026-03-24` 的普通文章 `case-study.md`。

2. 在 [`docs/.vitepress/data/posts.ts`](/private/tmp/repos/blog-system/docs/.vitepress/data/posts.ts) 增加首页分页数据函数，建议新增签名 `export function paginatePosts(posts: Post[], page: number, pageSize: number, options: Pick<PostFilterOptions, 'isProduction'> = {}): { items: Post[]; total: number; totalPages: number; currentPage: number }`。
   该函数必须直接复用现有 `getAllPosts(posts, options): Post[]` 的过滤与排序结果，确保首页与分类页、标签页、详情页相同地遵守 `shouldIncludePost(post, isProduction)` 和 `comparePosts(a, b)`；不要重复实现排序逻辑。
   具体值可先在组件侧固定 `pageSize = 5`，用当前仓库的 4 篇公开文章验证：`total = 4`、`totalPages = 1`，且结果顺序应为 `版本发布说明`、`专题复盘：从文档站到博客`、`标签整理方法`、`快速开始`。

3. 在 [`docs/.vitepress/types/post.ts`](/private/tmp/repos/blog-system/docs/.vitepress/types/post.ts) 增加首页分页返回类型，建议签名为 `export interface PostPage { items: Post[]; total: number; totalPages: number; currentPage: number; pageSize: number }`，供 [`docs/.vitepress/data/posts.ts`](/private/tmp/repos/blog-system/docs/.vitepress/data/posts.ts) 和首页组件共用。
   代码风格应对齐现有 `PostArchiveGroup`、`PostTagGroup`、`PostCategoryGroup` 这类聚合类型定义，避免在组件内内联复杂对象类型。
   这里不需要新增 frontmatter 字段，首页摘要继续使用已有 `PostFrontmatter.description: string`，置顶状态继续使用 `PostFrontmatter.pinned: boolean`。

4. 新增首页组件 [`docs/.vitepress/theme/components/HomePage.vue`](/private/tmp/repos/blog-system/docs/.vitepress/theme/components/HomePage.vue)，实现文章列表与分页 UI。
   组件脚本建议采用与 [`docs/.vitepress/theme/components/ArchivesPage.vue`](/private/tmp/repos/blog-system/docs/.vitepress/theme/components/ArchivesPage.vue) 相同的 `<script setup lang="ts">` + `computed` 模式，并从 `../../data/posts.data` 导入 `posts`，从 `../../data/posts` 导入 `paginatePosts`；页码状态建议使用 `const currentPage = ref(1)`，派生 `const pagedPosts = computed<PostPage>(() => paginatePosts(posts, currentPage.value, 5))`。
   每个列表项应渲染 `post.title`、`post.date`、`post.categories`、`post.tags`、`post.description`，分类与标签链接复用 [`docs/.vitepress/theme/components/PostMeta.vue`](/private/tmp/repos/blog-system/docs/.vitepress/theme/components/PostMeta.vue) 中 `normalizeCategorySlug(category)` / `normalizeTagSlug(tag)` + `withBase()` 的拼接模式；置顶标记基于 `post.pinned` 渲染固定文案，例如 `置顶`。
   分页交互建议使用明确按钮而不是无限滚动，至少包含 `上一页` / `下一页` 和页码文本；测试场景包括当前示例数据下分页控件禁用态，以及当后续文章数超过 `pageSize` 时切换页面后列表内容变化且置顶文章仍只出现在排序后的前置位置。

5. 在 [`docs/.vitepress/theme/style.css`](/private/tmp/repos/blog-system/docs/.vitepress/theme/style.css) 增加首页卡片、置顶徽标和分页控件样式，沿用当前主题变量体系如 `--site-surface`、`--site-accent`、`--site-border`、`--site-radius`。
   样式组织应参考现有 `.archives-page__hero`、`.archive-post`、`.post-meta__chip`、`.post-pagination__link` 的命名方式，新增类似 `.home-page`、`.post-card`、`.post-card__badge`、`.home-pagination` 这类块级类名，避免污染已有文章详情页样式。
   视觉上需要让置顶文章有明确标记但不改变数据顺序规则，且移动端下卡片元信息换行可读；验收重点是首页首屏能清楚看到置顶徽标、标题、日期、分类、标签、摘要，以及分页按钮状态。

6. 为首页组件抽取复用性较高的文章摘要卡片子组件，建议新增 [`docs/.vitepress/theme/components/PostCard.vue`](/private/tmp/repos/blog-system/docs/.vitepress/theme/components/PostCard.vue)，签名 `defineProps<{ post: Post }>()`。
   该组件应直接复用 [`docs/.vitepress/theme/components/PostMeta.vue`](/private/tmp/repos/blog-system/docs/.vitepress/theme/components/PostMeta.vue) 的展示思路，但按验收标准裁剪为列表场景，仅展示标题、日期、分类、标签、摘要和置顶标记，不展示封面；链接形式保持 `:href="withBase(post.url)"` 与归档页一致。
   这样可以让首页分页组件只负责 `v-for` 和分页状态，后续分类/标签详情页如果要升级成卡片视图，也能沿用同一渲染结构。

7. 补充数据层单元测试或最小验证脚本，优先放在 [`docs/.vitepress/data/posts.ts`](/private/tmp/repos/blog-system/docs/.vitepress/data/posts.ts) 附近的新测试文件中，例如新增 `paginatePosts()` 的顺序与边界验证。
   重点测试签名 `paginatePosts(posts: Post[], page: number, pageSize: number, options?: Pick<PostFilterOptions, 'isProduction'>)` 在以下场景的返回值：`page=1,pageSize=5` 返回全部 4 篇公开文章；包含 `draft: true` 的 `content-planning.md` 不出现在生产列表；当 `page` 超过总页数时回退到最后一页或空页，具体行为需在实现前固定。
   如果仓库当前尚未引入测试运行器，则至少在计划执行时补一轮 `npm run build` 验证首页组件、分页逻辑和全局组件注册不会破坏现有分类/标签/归档页面。

### Risks / Notes
- 该 issue 依赖 #55 和 #56；当前仓库已经存在 `posts.data.ts`、`posts.ts`、分类页、标签页、归档页，说明依赖大概率已落地，但执行前仍需确认这些改动已合并到目标分支，否则首页无法复用既有数据模型。
- “支持分页或无限滚动” 与验收标准“分页功能正常”存在取舍，建议明确采用分页，避免实现无限滚动后还要补分页。
- 现有仓库没有显式测试框架；如果不补测试文件，至少需要把 `paginatePosts()` 的边界处理写得足够确定，否则页码越界行为容易在联调时反复修改。

---
Reply with one of:
- `approve` — proceed with execution
- `skip` — ignore this issue
- `revise: <feedback>` — revise the plan with your feedback

### Codex Output (stdout)

```
首页已经改成真正的文章列表页了。`[docs/index.md](/private/tmp/repos/blog-system/docs/index.md#L1)` 现在挂载 `[HomePage.vue](/private/tmp/repos/blog-system/docs/.vitepress/theme/components/HomePage.vue#L1)`，并在 `[theme/index.ts](/private/tmp/repos/blog-system/docs/.vitepress/theme/index.ts#L1)` 注册全局组件。首页按现有 `getAllPosts()` 排序结果做分页，新增的 `[paginatePosts()](/private/tmp/repos/blog-system/docs/.vitepress/data/posts.ts#L222)` 和 `[PostPage](/private/tmp/repos/blog-system/docs/.vitepress/types/post.ts#L39)` 复用了已有的置顶优先和生产环境过滤逻辑，没有重复实现排序。

列表展示拆成了 `[PostCard.vue](/private/tmp/repos/blog-system/docs/.vitepress/theme/components/PostCard.vue#L1)`，每张卡片显示标题、日期、分类、标签、摘要，并对 `pinned` 文章渲染“置顶”标记。首页组件里用固定 `pageSize = 5` 做上一页/下一页分页，页码和总数也会显示。对应样式已补到 `[style.css](/private/tmp/repos/blog-system/docs/.vitepress/theme/style.css#L443)`，包括首页 hero、文章卡片、置顶徽标、分页按钮和移动端布局。

验证方面，当前环境没有安装依赖，`npm run build` 和 `npm run lint` 都失败在命令不存在：`vitepress: command not found`、`eslint: command not found`。装好依赖后需要再跑一次这两个命令确认通过。

```

Closes #58
