### PR TITLE
[AI Worker] 实现搜索功能

### DIFF
--- a/docs/.vitepress/data/search.data.ts
+++ b/docs/.vitepress/data/search.data.ts
@@ -1,0 +1,71 @@
+import { createContentLoader } from 'vitepress';
+import type { ContentData } from 'vitepress';
+import type { PostFrontmatter, SearchDocument } from '../types/post';
+import { shouldIncludePost } from './posts.data';
+
+const DEFAULT_IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
+type RawSearchContent = ContentData & {
+  frontmatter: PostFrontmatter;
+  src?: string;
+  srcPath?: string;
+};
+
+function stripFrontmatter(source: string): string {
+  return source.replace(/^---[\s\S]*?---\s*/u, '');
+}
+
+function stripMarkdown(source: string): string {
+  return source
+    .replace(/```[\s\S]*?```/gu, ' ')
+    .replace(/`([^`]+)`/gu, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/gu, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/gu, '$1')
+    .replace(/^#{1,6}\s+/gmu, '')
+    .replace(/^\s*>\s?/gmu, '')
+    .replace(/^\s*[-*+]\s+/gmu, '')
+    .replace(/^\s*\d+\.\s+/gmu, '')
+    .replace(/\|/gu, ' ')
+    .replace(/[*_~]/gu, '')
+    .replace(/<[^>]+>/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function resolveSlug(raw: RawSearchContent): string {
+  if (raw.srcPath) {
+    return raw.srcPath
+      .replace(/^.*\/posts\//u, '')
+      .replace(/\.md$/u, '');
+  }
+
+  return raw.url
+    .replace(/^\/posts\//u, '')
+    .replace(/\.html$/u, '')
+    .replace(/\/$/u, '');
+}
+
+function normalizeSearchDocument(raw: RawSearchContent): SearchDocument {
+  const slug = resolveSlug(raw);
+  const content = stripMarkdown(stripFrontmatter(raw.src ?? ''));
+
+  return {
+    title: raw.frontmatter.title,
+    description: raw.frontmatter.description,
+    content,
+    url: `/posts/${slug}`
+  };
+}
+
+const searchLoader = createContentLoader('posts/*.md', {
+  includeSrc: true,
+  transform(rawPosts) {
+    return rawPosts
+      .filter((rawPost) =>
+        shouldIncludePost((rawPost as RawSearchContent).frontmatter, DEFAULT_IS_PRODUCTION)
+      )
+      .map((rawPost) => normalizeSearchDocument(rawPost as RawSearchContent));
+  }
+});
+
+export default searchLoader;

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { Content, useData, useRoute, withBase } from 'vitepress';
+import searchDocuments from '../data/search.data';
+import type { SearchDocument } from '../types/post';
 import PostDetailLayout from './components/PostDetailLayout.vue';
 
 type NavItem = {
@@ -11,6 +13,9 @@ type NavItem = {
 const { site, theme } = useData();
 const route = useRoute();
 const isNavOpen = ref(false);
+const searchRoot = ref<HTMLElement | null>(null);
+const searchQuery = ref('');
+const isSearchOpen = ref(false);
 
 const isPostDetailPage = computed(() => {
   const currentPath = normalizePath(route.path);
@@ -20,6 +25,21 @@ const isPostDetailPage = computed(() => {
 const navItems = computed<NavItem[]>(() => {
   const nav = theme.value.nav;
   return Array.isArray(nav) ? (nav as NavItem[]) : [];
+});
+
+const normalizedQuery = computed(() => normalizeSearchText(searchQuery.value));
+const searchTerms = computed(() => tokenizeQuery(normalizedQuery.value));
+
+const searchResults = computed(() => {
+  if (!searchTerms.value.length) {
+    return [];
+  }
+
+  return searchDocuments
+    .map((document) => scoreSearchDocument(document, searchTerms.value))
+    .filter((result): result is SearchResult => result !== null)
+    .sort((resultA, resultB) => resultB.score - resultA.score)
+    .slice(0, 8);
 });
 
 function normalizePath(path: string): string {
@@ -45,14 +65,159 @@ function isActive(link: string): boolean {
   return currentPath === targetPath || currentPath.startsWith(targetPath);
 }
 
+function normalizeSearchText(value: string): string {
+  return value.trim().toLocaleLowerCase('zh-Hans-CN');
+}
+
+function tokenizeQuery(value: string): string[] {
+  return value
+    .split(/\s+/u)
+    .map((term) => term.trim())
+    .filter(Boolean);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function findTermIndex(text: string, terms: string[]): number {
+  const normalizedText = normalizeSearchText(text);
+  let matchedIndex = -1;
+
+  for (const term of terms) {
+    const index = normalizedText.indexOf(term);
+
+    if (index !== -1 && (matchedIndex === -1 || index < matchedIndex)) {
+      matchedIndex = index;
+    }
+  }
+
+  return matchedIndex;
+}
+
+function createSnippet(text: string, terms: string[]): string {
+  const snippetRadius = 52;
+  const matchIndex = findTermIndex(text, terms);
+
+  if (matchIndex === -1) {
+    return text.slice(0, 120).trim();
+  }
+
+  const start = Math.max(0, matchIndex - snippetRadius);
+  const end = Math.min(text.length, matchIndex + snippetRadius + 36);
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < text.length ? '...' : '';
+
+  return `${prefix}${text.slice(start, end).trim()}${suffix}`;
+}
+
+function highlightText(text: string, terms: string[]): string {
+  if (!text) {
+    return '';
+  }
+
+  const uniqueTerms = Array.from(new Set(terms)).sort((termA, termB) => termB.length - termA.length);
+
+  if (!uniqueTerms.length) {
+    return escapeHtml(text);
+  }
+
+  const pattern = new RegExp(`(${uniqueTerms.map((term) => escapeRegExp(term)).join('|')})`, 'giu');
+
+  return escapeHtml(text).replace(pattern, '<mark>$1</mark>');
+}
+
+type SearchResult = {
+  document: SearchDocument;
+  score: number;
+  snippet: string;
+};
+
+function scoreSearchDocument(document: SearchDocument, terms: string[]): SearchResult | null {
+  const title = normalizeSearchText(document.title);
+  const description = normalizeSearchText(document.description);
+  const content = normalizeSearchText(document.content);
+
+  let score = 0;
+
+  for (const term of terms) {
+    if (title.includes(term)) {
+      score += 12;
+    }
+
+    if (description.includes(term)) {
+      score += 6;
+    }
+
+    if (content.includes(term)) {
+      score += 4;
+    }
+  }
+
+  if (score === 0) {
+    return null;
+  }
+
+  return {
+    document,
+    score,
+    snippet: createSnippet(document.content || document.description, terms)
+  };
+}
+
+function openSearch(): void {
+  isSearchOpen.value = true;
+}
+
+function clearSearch(): void {
+  searchQuery.value = '';
+  isSearchOpen.value = false;
+}
+
+function onSearchInput(): void {
+  isSearchOpen.value = true;
+}
+
+function onSearchResultClick(): void {
+  isSearchOpen.value = false;
+}
+
+function handleDocumentClick(event: MouseEvent): void {
+  if (!(event.target instanceof Node)) {
+    return;
+  }
+
+  if (!searchRoot.value?.contains(event.target)) {
+    isSearchOpen.value = false;
+  }
+}
+
 const footerYear: number = new Date().getFullYear();
 
 watch(
   () => route.path,
   () => {
     isNavOpen.value = false;
+    isSearchOpen.value = false;
   }
 );
+
+onMounted(() => {
+  document.addEventListener('click', handleDocumentClick);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleDocumentClick);
+});
 </script>
 
 <template>
@@ -64,30 +229,90 @@ watch(
           <span class="site-brand__tagline">{{ site.description }}</span>
         </a>
 
-        <button
-          class="site-nav-toggle"
-          type="button"
-          :aria-expanded="String(isNavOpen)"
-          aria-controls="site-nav"
-          aria-label="Toggle navigation"
-          @click="isNavOpen = !isNavOpen"
-        >
-          <span class="site-nav-toggle__bar" />
-          <span class="site-nav-toggle__bar" />
-          <span class="site-nav-toggle__bar" />
-        </button>
+        <div class="site-header__actions">
+          <div ref="searchRoot" class="site-search" :class="{ 'is-open': isSearchOpen }">
+            <label class="site-search__field" for="site-search-input">
+              <span class="site-search__icon" aria-hidden="true">⌕</span>
+              <input
+                id="site-search-input"
+                v-model="searchQuery"
+                class="site-search__input"
+                type="search"
+                placeholder="搜索标题或正文"
+                autocomplete="off"
+                spellcheck="false"
+                @focus="openSearch"
+                @input="onSearchInput"
+              >
+              <button
+                v-if="searchQuery"
+                class="site-search__clear"
+                type="button"
+                aria-label="清空搜索"
+                @click="clearSearch"
+              >
+                ×
+              </button>
+            </label>
 
-        <nav id="site-nav" class="site-nav" :class="{ 'is-open': isNavOpen }" aria-label="Global">
-          <a
-            v-for="item in navItems"
-            :key="item.link"
-            class="site-nav__link"
-            :class="{ 'is-active': isActive(item.link) }"
-            :href="withBase(item.link)"
+            <div
+              v-if="isSearchOpen && normalizedQuery"
+              class="site-search__panel"
+              role="listbox"
+              aria-label="搜索结果"
+            >
+              <p class="site-search__summary">
+                找到 {{ searchResults.length }} 条与 “{{ searchQuery.trim() }}” 相关的结果
+              </p>
+
+              <ul v-if="searchResults.length" class="site-search__results">
+                <li v-for="result in searchResults" :key="result.document.url" class="site-search-result">
+                  <a
+                    class="site-search-result__link"
+                    :href="withBase(result.document.url)"
+                    @click="onSearchResultClick"
+                  >
+                    <strong
+                      class="site-search-result__title"
+                      v-html="highlightText(result.document.title, searchTerms)"
+                    ></strong>
+                    <p
+                      class="site-search-result__snippet"
+                      v-html="highlightText(result.snippet, searchTerms)"
+                    ></p>
+                  </a>
+                </li>
+              </ul>
+
+              <p v-else class="site-search__empty">未找到匹配结果，请尝试更换关键词。</p>
+            </div>
+          </div>
+
+          <button
+            class="site-nav-toggle"
+            type="button"
+            :aria-expanded="String(isNavOpen)"
+            aria-controls="site-nav"
+            aria-label="Toggle navigation"
+            @click="isNavOpen = !isNavOpen"
           >
-            {{ item.text }}
-          </a>
-        </nav>
+            <span class="site-nav-toggle__bar" />
+            <span class="site-nav-toggle__bar" />
+            <span class="site-nav-toggle__bar" />
+          </button>
+
+          <nav id="site-nav" class="site-nav" :class="{ 'is-open': isNavOpen }" aria-label="Global">
+            <a
+              v-for="item in navItems"
+              :key="item.link"
+              class="site-nav__link"
+              :class="{ 'is-active': isActive(item.link) }"
+              :href="withBase(item.link)"
+            >
+              {{ item.text }}
+            </a>
+          </nav>
+        </div>
       </div>
     </header>
 

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -71,6 +71,14 @@ a {
   gap: 1.5rem;
 }
 
+.site-header__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+  flex: 1;
+}
+
 .site-brand {
   display: inline-flex;
   flex-direction: column;
@@ -94,6 +102,137 @@ a {
   align-items: center;
   gap: 0.6rem;
   flex-wrap: wrap;
+}
+
+.site-search {
+  position: relative;
+  width: min(24rem, 100%);
+}
+
+.site-search__field {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-height: 46px;
+  padding: 0 0.9rem;
+  border: 1px solid rgba(29, 111, 95, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 10px 24px rgba(31, 41, 51, 0.04);
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.site-search.is-open .site-search__field,
+.site-search__field:focus-within {
+  border-color: rgba(29, 111, 95, 0.34);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 16px 30px rgba(31, 41, 51, 0.08);
+}
+
+.site-search__icon {
+  color: var(--site-muted);
+  font-size: 1rem;
+}
+
+.site-search__input {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--site-text);
+  font: inherit;
+}
+
+.site-search__input:focus {
+  outline: none;
+}
+
+.site-search__input::placeholder {
+  color: color-mix(in srgb, var(--site-muted) 82%, white);
+}
+
+.site-search__clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(29, 111, 95, 0.1);
+  color: var(--site-accent);
+  font: inherit;
+  cursor: pointer;
+}
+
+.site-search__panel {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  left: 0;
+  right: 0;
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  border: 1px solid var(--site-border);
+  border-radius: var(--site-radius-sm);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: var(--site-shadow);
+}
+
+.site-search__summary,
+.site-search__empty {
+  margin: 0;
+  color: var(--site-muted);
+  font-size: 0.92rem;
+}
+
+.site-search__results {
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-search-result__link {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--site-radius-sm);
+  text-decoration: none;
+  background: linear-gradient(135deg, rgba(29, 111, 95, 0.08), rgba(255, 255, 255, 0.96));
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.site-search-result__link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(31, 41, 51, 0.07);
+}
+
+.site-search-result__title {
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.site-search-result__snippet {
+  margin: 0;
+  color: var(--site-muted);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.site-search :is(mark, .site-search-result__title mark, .site-search-result__snippet mark) {
+  padding: 0 0.18em;
+  border-radius: 0.3em;
+  background: rgba(242, 191, 73, 0.32);
+  color: inherit;
 }
 
 .site-nav__link {
@@ -901,6 +1040,15 @@ a {
     gap: 1rem;
   }
 
+  .site-header__actions {
+    gap: 0.75rem;
+  }
+
+  .site-search {
+    width: auto;
+    flex: 1;
+  }
+
   .site-brand__name {
     font-size: 1rem;
   }
@@ -926,6 +1074,11 @@ a {
     box-shadow: var(--site-shadow);
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .site-search__panel {
+    left: 0;
+    right: calc(-44px - 0.75rem);
   }
 
   .site-nav.is-open {
@@ -1039,5 +1192,24 @@ a {
   .tag-chip {
     width: 100%;
     justify-content: space-between;
+  }
+}
+
+@media (max-width: 560px) {
+  .site-header__inner {
+    flex-wrap: wrap;
+  }
+
+  .site-header__actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .site-search {
+    min-width: 0;
+  }
+
+  .site-search__panel {
+    right: 0;
   }
 }

--- a/docs/.vitepress/types/post.ts
+++ b/docs/.vitepress/types/post.ts
@@ -15,6 +15,13 @@ export interface Post extends PostFrontmatter {
   month: string;
 }
 
+export interface SearchDocument {
+  title: string;
+  description: string;
+  content: string;
+  url: string;
+}
+
 export interface PostArchiveGroup {
   month: string;
   label: string;


### PR DESCRIPTION
## Summary

This PR was generated automatically by AI Worker for issue #57.

### Plan

## AI Worker Plan

**Issue:** #57 — 实现搜索功能

### Understanding
需要在现有 VitePress 博客中接入本地全文搜索，覆盖文章标题和正文内容，并在搜索结果中高亮关键词。实现应优先复用 VitePress 站点配置与主题扩展入口，保证搜索在静态站点中响应足够快，且与 #55 产出的文章数据结构兼容。

### Proposed Steps
1. 在 [package.json](/private/tmp/repos/blog-system/package.json) 的 `devDependencies` 与脚本约束下接入本地搜索依赖，新增或调整 `docs/.vitepress/config.ts` 中的 `export default defineConfig({...})` 配置，优先添加 `themeConfig.search` 字段而不是自定义全量搜索页。参考该文件当前 `themeConfig.nav` / `socialLinks` 的对象字面量写法，配置 `provider: 'local'` 或等效的 `minisearch` 集成，并显式启用对 Markdown 内容的索引选项，使 `docs/posts/getting-started.md`、[docs/posts/case-study.md](/private/tmp/repos/blog-system/docs/posts/case-study.md) 等文章的标题与正文都进入索引。

2. 修改 [docs/.vitepress/config.ts](/private/tmp/repos/blog-system/docs/.vitepress/config.ts) 中 `defineConfig` 的站点搜索行为配置，补充本地搜索的中文分词/文本提取相关选项；如果采用 `vitepress-plugin-search`，则新增配置函数签名 `SearchPlugin(options)` 的调用并在同文件注册 `vite`/`transformPageData` 扩展。参考当前单文件集中导出配置的模式，把标题字段映射到 Markdown `frontmatter.title`，把正文字段映射到页面 `content`，并限定索引目录为 `docs/posts/*.md`，避免把分类页、标签页、归档页重复内容一并索引影响性能。

3. 在 [docs/.vitepress/theme/index.ts](/private/tmp/repos/blog-system/docs/.vitepress/theme/index.ts) 的 `const theme = { extends: DefaultTheme, Layout, enhanceApp({ app }) { ... } } satisfies Theme;` 结构内接入搜索 UI 所需的主题增强逻辑。若本地搜索方案要求注册组件或覆盖默认布局，则在 `enhanceApp({ app })` 中新增明确的方法调用，例如 `enhanceApp({ app, router, siteData })` 里注册搜索组件，保持与现有 `app.component('HomePage', HomePage)` 的注册模式一致，不单独创建无关入口。

4. 修改 [docs/.vitepress/theme/Layout.vue](/private/tmp/repos/blog-system/docs/.vitepress/theme/Layout.vue) 中现有布局组件，加入搜索框挂载位置与结果面板容器；需要明确修改该组件的 `<script setup lang="ts">` 或等效逻辑，新增如 `function onSearchSelect(url: string): void`、`function renderHighlightedText(text: string, query: string): string` 之类的处理函数。模式上沿用该主题对 `DefaultTheme.Layout` 的包装方式，把搜索框放在顶部导航区域或页面头部，确保输入关键词后可以展示匹配标题、正文摘要和跳转链接。

5. 在 [docs/.vitepress/theme/style.css](/private/tmp/repos/blog-system/docs/.vitepress/theme/style.css) 中补充搜索结果与高亮样式，新增针对搜索弹层/下拉列表及命中词的 CSS 规则，例如 `.search-result mark { ... }` 或插件要求的 `.DocSearch-Hit mark` / `.vp-search-result__highlight`。参考该文件现有主题样式组织方式，统一使用当前主题变量，确保高亮不仅作用于标题，也作用于正文摘录中的匹配关键字。

6. 基于 #55 的文章元数据输出结果，校验搜索索引是否正确覆盖文章标题和正文内容；若 #55 在 [docs/.vitepress/theme/index.ts](/private/tmp/repos/blog-system/docs/.vitepress/theme/index.ts) 或新增数据文件中暴露文章列表，则在搜索配置中复用同一数据来源，避免重复扫描。至少以 [docs/posts/getting-started.md](/private/tmp/repos/blog-system/docs/posts/getting-started.md)、[docs/posts/content-planning.md](/private/tmp/repos/blog-system/docs/posts/content-planning.md)、[docs/posts/release-notes.md](/private/tmp/repos/blog-system/docs/posts/release-notes.md) 作为验证样本，覆盖“标题命中”“正文命中”“中英文关键词命中”三类场景。

7. 为搜索行为补充自动化验证，新增测试文件到现有主题源码目录下，例如 [docs/.vitepress/theme/search.spec.ts](/private/tmp/repos/blog-system/docs/.vitepress/theme/search.spec.ts) 或与实现文件同目录测试；测试中显式覆盖函数签名 `renderHighlightedText(text: string, query: string): string`、`extractSearchDocument(page: PageData): SearchDocument | null`、`createSearchIndex(docs: SearchDocument[]): MiniSearch<SearchDocument>` 中至少一项。测试用例应验证：搜索“getting”可命中文章标题，搜索正文中的特定关键词可返回摘要片段，匹配词被 `<mark>` 或对应高亮标记包裹，且分类/标签聚合页不会被误加入索引。

8. 运行并通过仓库现有验证命令，对应 [package.json](/private/tmp/repos/blog-system/package.json) 中的 `npm run lint`、`npm run build`；必要时调整 [eslint.config.js](/private/tmp/repos/blog-system/eslint.config.js) 的 `files: ['docs/.vitepress/**/*.ts', 'components/**/*.ts']` 范围，确保新增的搜索实现文件与测试文件被正确检查。构建后重点确认静态产物中搜索初始化不会阻塞首页渲染，搜索输入能在文章数量增加时保持即时返回。

### Risks / Notes
- `depends on #55` 意味着搜索最好复用 #55 生成的文章元数据；如果 #55 尚未落地，直接扫描 Markdown 可能会导致后续重复实现或索引字段不一致。
- VitePress 2.0 alpha 版本的本地搜索 API 可能仍有变动，`provider: 'local'` 与第三方 `vitepress-plugin-search` 的配置方式需要以当前项目实际可用版本为准。
- 中文关键词高亮与分词效果取决于所选方案；若默认分词不足，可能需要额外 tokenizer 配置，否则“标题和正文可搜”会达标但命中质量不稳定。

---
Reply with one of:
- `approve` — proceed with execution
- `skip` — ignore this issue
- `revise: <feedback>` — revise the plan with your feedback

### Codex Output (stdout)

```
实现了本地全文搜索，直接复用 VitePress 的内容 loader 生成静态索引，支持文章标题和正文命中，并在结果里对关键词做高亮。搜索 UI 接在站点头部，结果按标题/摘要/正文命中做了简单加权，返回前 8 条，响应是前端本地计算，不依赖远端服务。

改动在 [Layout.vue](/private/tmp/repos/blog-system/docs/.vitepress/theme/Layout.vue)、[style.css](/private/tmp/repos/blog-system/docs/.vitepress/theme/style.css)、[search.data.ts](/private/tmp/repos/blog-system/docs/.vitepress/data/search.data.ts) 和 [post.ts](/private/tmp/repos/blog-system/docs/.vitepress/types/post.ts)。其中 [search.data.ts](/private/tmp/repos/blog-system/docs/.vitepress/data/search.data.ts) 会提取 `posts/*.md` 的标题、摘要、正文纯文本和 URL，布局层负责搜索、摘要截取和 `<mark>` 高亮，样式层补了搜索框、结果面板和移动端适配。

验证没法在当前环境完成：`npm run lint` 和 `npm run build` 都失败，因为本机这个仓库当前没有安装依赖，`eslint` 和 `vitepress` 命令都不存在。未修改任何测试文件。

```

Closes #57
